### PR TITLE
One time payments now create invoices

### DIFF
--- a/classes/class-rwstripe-stripe.php
+++ b/classes/class-rwstripe-stripe.php
@@ -408,7 +408,7 @@ class RWStripe_Stripe {
 			$checkout_session_parmas['subscription_data'] = array(
 				'application_fee_percent' => 2,
 			);
-			$checkout_session_params['payment_method_collection']['enabled'] = true;
+			$checkout_session_params['payment_method_collection'] = 'if_required';
 		} else {
 			// If price is one-time, set up payment params.
 			$checkout_session_params['mode'] = 'payment';


### PR DESCRIPTION
Previously, when a one-time payment price was purchased, we would also have to create a free subscription to track membership access to the site.

Stripe recently added a setting to have one-time payment checkouts create invoices. Using this new feature, we can scrap that old "free subscription" workaround and determine access by whether the user either:
1. Has an active subscription for a product
2. Has a paid "one-time payment" invoice for the product

This change reduces "custom" behavior in the plugin and opens the possibilities for future development.

Note: As you cannot "void" an already paid invoice, you can remove access given by a particular Stripe invoice by setting its `rwstripe-ignore` metadata